### PR TITLE
Optimize board rendering

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,18 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import flag from 'flag-svgrepo-com.svg';
-interface Cell {
-    row: number;
-    col: number;
-    point:number|null,
-    bomb:boolean,
-    isHide: boolean;
-    flag:boolean
-}
+import React, {useEffect, useState, useCallback} from 'react';
+import { Cell } from 'types';
+import CellComponent from './Cell';
 
-function randomInteger(min:any, max:any) {
-    // получить случайное число от (min-0.5) до (max+0.5)
-    let rand = min - 0.5 + Math.random() * (max - min + 1);
-    return Math.round(rand);
+function randomInteger(min: number, max: number) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 function generateBombs(count:any) {
     let bombArr = []
@@ -80,7 +71,7 @@ function App() {
         setState(generateMap(9,9,bombs))
     }, []);
 
-    function onClick(cell:Omit<Cell,'isHide'|'bomb'|'point'|'flag'>,state:Cell[]) {
+    const handleClick = useCallback((cell: Omit<Cell, 'isHide' | 'bomb' | 'point' | 'flag'>, state: Cell[]) => {
         const findIndex = state.findIndex(_ => _.row === cell.row && _.col === cell.col);
         const copyState = [...state];
         if (findIndex >= 0) {
@@ -111,13 +102,14 @@ function App() {
             do{
                 const item = arrChecks[arrChecks.length - 1];
                 if (item) {
-                    onClick(item,copyState);
+                    handleClick(item,copyState);
                 }
                 arrChecks.pop()
             }while (arrChecks.length)
         }
-    }
-    function onContext(cell:Omit<Cell,'isHide'|'bomb'|'point'|'flag'>) {
+    }, [setState, setGameOver]);
+
+    const handleContext = useCallback((cell: Omit<Cell,'isHide'|'bomb'|'point'|'flag'>) => {
         const findIndex = state.findIndex(_ => _.row === cell.row && _.col === cell.col);
         const copyState = [...state];
         if (findIndex >= 0) {
@@ -126,52 +118,35 @@ function App() {
             copyState.splice(findIndex,1,find)
             setState(copyState)
         }
-    }
+    }, [state]);
 
-    const renderCell = (cell:Cell) => {
-        if (cell.flag) return <img src={flag} alt="flag"/>
-        if (cell.isHide) return null;
-        if (!cell.bomb) return cell.point || null
-        return "B"
-    };
-
-    const getCellStyle = (cell:Cell) => {
-        if (cell.isHide || cell.flag) return 'darkgray'
-        if (cell.point === 0) return 'gray'
-        if (cell.bomb) return 'red'
-        return 'darkgray'
-    };
 
     return (
         <>
         <div className={'board'}>
-            {state.map((_,index) => {
-                return <div key={index}
-                            onClick={(e)=> {
-                                e.stopPropagation()
-                                if (gameOver || _.flag) return
-                                const {row,col} = _
-                                onClick({row,col},state)
-                            }}
-                            onContextMenu={(e)=>{
-                                e.preventDefault()
-                                const {row,col} = _
-                                onContext({row,col})
-                            }}
-                            className={'cell'}
-                            style={{
-                                background:getCellStyle(_)
-                }}>{renderCell(_)}</div>
-            })}
+            {state.map((cell, index) => (
+                <CellComponent
+                    key={index}
+                    data={cell}
+                    onClick={() => {
+                        if (gameOver || cell.flag) return;
+                        const { row, col } = cell;
+                        handleClick({ row, col }, state);
+                    }}
+                    onContext={() => {
+                        const { row, col } = cell;
+                        handleContext({ row, col });
+                    }}
+                />
+            ))}
 
         </div>
-            <button onClick={()=> {
+            <button onClick={() => {
                 const bombs = generateBombs(15);
-                setState(generateMap(9,9,bombs))
-                setGameOver(false)
+                setState(generateMap(9, 9, bombs));
+                setGameOver(false);
             }}>new game</button>
         </>
     );
 }
-//
 export default App;

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Cell as CellType } from 'types';
+import flag from 'flag-svgrepo-com.svg';
+
+interface Props {
+  data: CellType;
+  onClick: () => void;
+  onContext: () => void;
+}
+
+const getCellStyle = (cell: CellType): string => {
+  if (cell.isHide || cell.flag) return 'darkgray';
+  if (cell.point === 0) return 'gray';
+  if (cell.bomb) return 'red';
+  return 'darkgray';
+};
+
+const renderContent = (cell: CellType) => {
+  if (cell.flag) return <img src={flag} alt="flag" />;
+  if (cell.isHide) return null;
+  if (!cell.bomb) return cell.point || null;
+  return 'B';
+};
+
+const Cell: React.FC<Props> = ({ data, onClick, onContext }) => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    onClick();
+  };
+
+  const handleContext = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    onContext();
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      onContextMenu={handleContext}
+      className={'cell'}
+      style={{ background: getCellStyle(data) }}
+    >
+      {renderContent(data)}
+    </div>
+  );
+};
+
+export default React.memo(Cell);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface Cell {
+    row: number;
+    col: number;
+    point: number | null;
+    bomb: boolean;
+    isHide: boolean;
+    flag: boolean;
+}


### PR DESCRIPTION
## Summary
- add typed Cell interface
- add memoized `Cell` component to minimize unnecessary re-renders
- simplify random integer generation and add stable callbacks

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6880b49c2c108328ae1d07dbf0af7468